### PR TITLE
Clean things up/refactor a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,6 @@ run:
 	docker run --rm -it \
 	    -v $$(pwd):/shared --workdir /shared \
 	    -e DISCORD_WEBHOOK=$(DISCORD_WEBHOOK) \
+	    -e DISCORD_WEBHOOK_WHALES=$(DISCORD_WEBHOOK_WHALES) \
 	    kolibri-quipu-tradebot \
 	    python3 /shared/main.py

--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ def watch_for_changes():
 
     while True:
         try:
-            (new_quipu_transfers, latest_quipu_ophash) = fetch_contract_transfers(QUIPU_KUSD, since_hash=latest_quipu_ophash)
+            new_quipu_transfers, latest_quipu_ophash = fetch_contract_transfers(QUIPU_KUSD, since_hash=latest_quipu_ophash)
 
             new_plenty_transfers, latest_plenty_ophash = fetch_contract_transfers(PLENTY_KUSD, since_hash=latest_plenty_ophash)
 

--- a/main.py
+++ b/main.py
@@ -167,11 +167,9 @@ def handle_new_transfers(transfers):
             else:
                 continue
 
-        channel = DISCORD_WEBHOOK
+        send_discord(payload, DISCORD_WEBHOOK)
         if int(tx['amount']) / 1e18 >= 5000 and DISCORD_WEBHOOK_WHALES is not None:
-            channel = DISCORD_WEBHOOK_WHALES
-
-        send_discord(payload,channel)
+            send_discord(payload, DISCORD_WEBHOOK_WHALES)
 
 def watch_for_changes():
     if os.path.exists('.shared/previous-state.json'):

--- a/main.py
+++ b/main.py
@@ -8,8 +8,11 @@ import requests
 
 load_dotenv()
 
-whales = [] #define whale variable for use between functions
+whales = [] # define whale variable for use between functions
 
+QUIPU_KUSD = 'KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6'
+PLENTY_KUSD = 'KT1UNBvCJXiwJY6tmHM7CJUVwNPew53XkSfh'
+PLENTY_USDTZ_KUSD = 'KT1TnsQ6JqzyTz5PHMsGj28WwJyBtgc146aJ'
 
 # Configure Discord
 try:
@@ -19,14 +22,10 @@ try:
 except KeyError as e:
     raise Exception("DISCORD_WEBHOOK envar not found! You must set a DISCORD_WEBHOOK for things to work properly.")
 
-DISCORD_WEBHOOK_WHALES = None
-try:
-    DISCORD_WEBHOOK_WHALES = os.environ["DISCORD_WEBHOOK_WHALES"]
-    if len(DISCORD_WEBHOOK_WHALES) < 5:
-        raise KeyError
-except KeyError as e:
-    print ("DISCORD_WEBHOOK_WHALES envar not found! Whale trades will not be separated.")
-    pass
+DISCORD_WEBHOOK_WHALES = os.environ.get("DISCORD_WEBHOOK_WHALES", None)
+# If we have an empty string or something, just revert to None
+if DISCORD_WEBHOOK_WHALES is not None and len(DISCORD_WEBHOOK_WHALES) < 5:
+    DISCORD_WEBHOOK_WHALES = None
 
 def send_discord(payload,channel):
     print("Submitting webhook...")
@@ -41,57 +40,19 @@ def send_discord(payload,channel):
 
     return response
 
-
-#fetch whales with large ovens to mark their trades
+# fetch whales with large ovens to mark their trades
 def fetch_whales():
-    
-    whaleSize = 100000 #size threshold
-    whaleSize = whaleSize * 1e18 #convert using mantissa
+    whaleSize = 100_000 # size threshold in kUSD
+    whaleSize = whaleSize * 1e18 # convert using mantissa
     ovens = requests.get(
-            'https://kolibri-data.s3.amazonaws.com/mainnet/oven-data.json'
-        )
-
+        'https://kolibri-data.s3.amazonaws.com/mainnet/oven-data.json'
+    )
 
     for oven in ovens.json()['allOvenData']:
         if int(float(oven['outstandingTokens'])) > whaleSize:
             whales.append(oven['ovenOwner'])
 
-
-def fetch_usdtz_plenty_activity(since_hash=None):
-    params = {
-        "token_id": 0,
-        "size": 10,
-        "contracts": "KT1K9gCRgaLRFKTErYt1wVxA3Frb9FjasjTV",
-    }
-    
-    transfers = []
-
-    last_id = None
-
-    while True:
-        if last_id is not None:
-            params['last_id'] = last_id
-
-        response = requests.get(
-            'https://api.better-call.dev/v1/tokens/mainnet/transfers/KT1TnsQ6JqzyTz5PHMsGj28WwJyBtgc146aJ',
-            params=params
-        )
-
-        applied_ops = response.json()
-
-        last_id = applied_ops['last_id']
-
-
-        for operation in applied_ops['transfers']:
-            if operation['hash'] == since_hash:
-                return transfers
-            if operation['status'] == 'applied':
-                transfers.append(operation)
-
-        if since_hash is None:
-            return transfers
-        
-def fetch_plenty_activity(since_hash=None):
+def fetch_contract_transfers(contract_address, since_hash=None):
     params = {
         "token_id": 0,
         "size": 10,
@@ -107,40 +68,7 @@ def fetch_plenty_activity(since_hash=None):
             params['last_id'] = last_id
 
         response = requests.get(
-            'https://api.better-call.dev/v1/tokens/mainnet/transfers/KT1UNBvCJXiwJY6tmHM7CJUVwNPew53XkSfh',
-            params=params
-        )
-
-        applied_ops = response.json()
-        last_id = applied_ops['last_id']
-
-        for operation in applied_ops['transfers']:
-            if operation['hash'] == since_hash:
-                return transfers
-            if operation['status'] == 'applied':
-                transfers.append(operation)
-            
-        if since_hash is None:
-            return transfers
-  
-        
-def fetch_quipuswap_activity(since_hash=None):
-    params = {
-        "token_id": 0,
-        "size": 10,
-        "contracts": "KT1K9gCRgaLRFKTErYt1wVxA3Frb9FjasjTV",
-    }
-    
-    transfers = []
-
-    last_id = None
-
-    while True:
-        if last_id is not None:
-            params['last_id'] = last_id
-
-        response = requests.get(
-            'https://api.better-call.dev/v1/tokens/mainnet/transfers/KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6',
+            'https://api.better-call.dev/v1/tokens/mainnet/transfers/{}'.format(contract_address),
             params=params
         )
 
@@ -150,158 +78,102 @@ def fetch_quipuswap_activity(since_hash=None):
 
         for operation in applied_ops['transfers']:
             if operation['hash'] == since_hash:
-                return transfers
+                return transfers, applied_ops['transfers'][0]['hash']
             if operation['status'] == 'applied':
                 transfers.append(operation)
 
         if since_hash is None:
-            return transfers
-    
-
-latest_quipu_ophash = None
-latest_plenty_ophash = None
-latest_usdtz_plenty_ophash = None
-
-def fetch_all_new_transfers(quipuhash,plentyhash,usdtzhash):
-    all_transfers = []
-    
-    new_quipu_transfers = fetch_quipuswap_activity(since_hash=quipuhash)
-    new_plenty_transfers = fetch_plenty_activity(since_hash=plentyhash)
-    new_usdtz_plenty_transfers = fetch_usdtz_plenty_activity(since_hash=usdtzhash)
-    
-    all_transfers = new_quipu_transfers + new_plenty_transfers + new_usdtz_plenty_transfers
-
-    try:
-        latest_quipu_ophash = new_quipu_transfers[0]['hash']
-    except IndexError:
-        latest_quipu_ophash = quipuhash
-    try:
-        latest_plenty_ophash = new_plenty_transfers[0]['hash']
-    except IndexError:
-        latest_plenty_ophash = plentyhash
-    try:
-        latest_usdtz_plenty_ophash = new_usdtz_plenty_transfers[0]['hash']
-    except IndexError:
-       latest_usdtz_plenty_ophash = usdtzhash
-    
-    return all_transfers, latest_quipu_ophash, latest_plenty_ophash, latest_usdtz_plenty_ophash
+            return transfers, transfers[0]['hash']
 
 def shorten_address(address):
     return address[:5] + "..." + address[-5:]
 
 def handle_new_transfers(transfers):
-
-    
-    
-    #xtz/kusd trades on quipuswap
     for tx in transfers:
         payload = {}
-        if tx['parent'] == 'tokenToTezPayment':
-            payload["content"] = "<:quipuswap:906262514197749831> {} sold :chart_with_downwards_trend: **{:,} kUSD** - **[TX](<{}>)**".format(
-                '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['from']), tx['from']),
-                round(int(tx['amount']) / 1e18, 2),
-                'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
-            )
 
-            if tx['from'] in whales:
-                payload["content"] = payload["content"] + " :whale:"
-                
+        # if it is Quipu XTZ/kUSD contract
+        if tx['from'] == QUIPU_KUSD or tx['to'] == QUIPU_KUSD:  # if it is plenty/kusd contract
+            if tx['parent'] == 'tokenToTezPayment':
+                payload["content"] = "<:quipuswap:906262514197749831> {} sold :chart_with_downwards_trend: **{:,} kUSD** - **[TX](<{}>)**".format(
+                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['from']), tx['from']),
+                    round(int(tx['amount']) / 1e18, 2),
+                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
+                )
 
-        elif tx['parent'] == 'tezToTokenPayment':
-            payload["content"] = "<:quipuswap:906262514197749831> {} bought :chart_with_upwards_trend: **{:,} kUSD** - **[TX](<{}>)**".format(
-                '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['to']), tx['to']),
-                round(int(tx['amount']) / 1e18, 2),
-                'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
-            )
+                if tx['from'] in whales:
+                    payload["content"] = payload["content"] + " :whale:"
 
-            if tx['to'] in whales:
-                payload["content"] = payload["content"] + " :whale:"
-            
-        else:
-            continue
+            elif tx['parent'] == 'tezToTokenPayment':
+                payload["content"] = "<:quipuswap:906262514197749831> {} bought :chart_with_upwards_trend: **{:,} kUSD** - **[TX](<{}>)**".format(
+                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['to']), tx['to']),
+                    round(int(tx['amount']) / 1e18, 2),
+                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
+                )
+
+                if tx['to'] in whales:
+                    payload["content"] = payload["content"] + " :whale:"
+
+            else:
+                continue
+
+        # if it is PLENTY/kUSD contract
+        if tx['from'] == PLENTY_KUSD or tx['to'] == PLENTY_KUSD: # if it is plenty/kusd contract
+            if tx['parent'] == 'Swap' and tx['from'] != PLENTY_KUSD:
+                payload["content"] = "<:plenty:897260943090798622> {} sold :chart_with_downwards_trend: **{:,} kUSD** for **PLENTY** - **[TX](<{}>)**".format(
+                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['from']), tx['from']),
+                    round(int(tx['amount']) / 1e18, 2),
+                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
+                )
+
+                if tx['from'] in whales:
+                    payload["content"] = payload["content"] + " :whale:"
+
+            elif tx['parent'] == 'Swap':
+                payload["content"] = "<:plenty:897260943090798622> {} bought :chart_with_upwards_trend: **{:,} kUSD** with **PLENTY** - **[TX](<{}>)**".format(
+                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['to']), tx['to']),
+                    round(int(tx['amount']) / 1e18, 2),
+                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
+                )
+
+                if tx['to'] in whales:
+                    payload["content"] = payload["content"] + " :whale:"
+
+            else:
+                continue
+
+        # if it is USDTz/kUSD contract
+        if tx['from'] == PLENTY_USDTZ_KUSD or tx['to'] == PLENTY_USDTZ_KUSD:
+            if tx['parent'] == 'Swap' and tx['from'] != PLENTY_USDTZ_KUSD:
+                payload["content"] = "<:plenty:897260943090798622> {} sold :chart_with_downwards_trend: **{:,} kUSD** for **USDtz** - **[TX](<{}>)**".format(
+                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['from']), tx['from']),
+                    round(int(tx['amount']) / 1e18, 2),
+                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
+                )
+
+                if tx['from'] in whales:
+                    payload["content"] = payload["content"] + " :whale:"
+
+            elif tx['parent'] == 'Swap':
+                payload["content"] = "<:plenty:897260943090798622> {} bought :chart_with_upwards_trend: **{:,} kUSD** with **USDtz** - **[TX](<{}>)**".format(
+                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['to']), tx['to']),
+                    round(int(tx['amount']) / 1e18, 2),
+                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
+                )
+
+                if tx['to'] in whales:
+                    payload["content"] = payload["content"] + " :whale:"
+
+            else:
+                continue
 
         channel = DISCORD_WEBHOOK
         if int(tx['amount']) / 1e18 >= 5000 and DISCORD_WEBHOOK_WHALES is not None:
             channel = DISCORD_WEBHOOK_WHALES
-         
+
         send_discord(payload,channel)
 
-
-    #plenty/kusd trades on plenty
-    for tx in transfers:
-        payload_plenty = {}
-        if tx['from'] == 'KT1UNBvCJXiwJY6tmHM7CJUVwNPew53XkSfh' or tx['to'] == 'KT1UNBvCJXiwJY6tmHM7CJUVwNPew53XkSfh':      #if it is plenty/kusd contract
-            if tx['parent'] == 'Swap' and tx['from'] != 'KT1UNBvCJXiwJY6tmHM7CJUVwNPew53XkSfh':
-                payload_plenty["content"] = "<:plenty:897260943090798622> {} sold :chart_with_downwards_trend: **{:,} kUSD** for **PLENTY** - **[TX](<{}>)**".format(
-                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['from']), tx['from']),
-                    round(int(tx['amount']) / 1e18, 2),
-                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
-                )
-
-                if tx['from'] in whales:
-                    payload_plenty["content"] = payload_plenty["content"] + " :whale:"
-                
-
-            elif tx['parent'] == 'Swap':
-                payload_plenty["content"] = "<:plenty:897260943090798622> {} bought :chart_with_upwards_trend: **{:,} kUSD** with **PLENTY** - **[TX](<{}>)**".format(
-                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['to']), tx['to']),
-                    round(int(tx['amount']) / 1e18, 2),
-                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
-                )
-
-                if tx['to'] in whales:
-                    payload_plenty["content"] = payload_plenty["content"] + " :whale:"
-                    
-
-                
-            else:
-                continue
-
-            channel = DISCORD_WEBHOOK
-            if int(tx['amount']) / 1e18 >= 5000 and DISCORD_WEBHOOK_WHALES is not None:
-                channel = DISCORD_WEBHOOK_WHALES
-            
-            send_discord(payload_plenty,channel)
-
-    #usdtz/kusd trades on plenty
-    for tx in transfers:
-        payload_usdtz_plenty = {}
-        if tx['from'] == 'KT1TnsQ6JqzyTz5PHMsGj28WwJyBtgc146aJ' or tx['to'] == 'KT1TnsQ6JqzyTz5PHMsGj28WwJyBtgc146aJ':      #if it is usdtz/kusd contract
-            if tx['parent'] == 'Swap' and tx['from'] != 'KT1TnsQ6JqzyTz5PHMsGj28WwJyBtgc146aJ':
-                payload_usdtz_plenty["content"] = "<:plenty:897260943090798622> {} sold :chart_with_downwards_trend: **{:,} kUSD** for **USDtz** - **[TX](<{}>)**".format(
-                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['from']), tx['from']),
-                    round(int(tx['amount']) / 1e18, 2),
-                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
-                )
-
-                if tx['from'] in whales:
-                    payload_usdtz_plenty["content"] = payload_usdtz_plenty["content"] + " :whale:"
-                    
-
-            elif tx['parent'] == 'Swap':
-                payload_usdtz_plenty["content"] = "<:plenty:897260943090798622> {} bought :chart_with_upwards_trend: **{:,} kUSD** with **USDtz** - **[TX](<{}>)**".format(
-                    '**[{}](<https://tzkt.io/{}>)**'.format(shorten_address(tx['to']), tx['to']),
-                    round(int(tx['amount']) / 1e18, 2),
-                    'https://better-call.dev/mainnet/opg/{}'.format(tx['hash'])
-                )
-
-                if tx['to'] in whales:
-                    payload_usdtz_plenty["content"] = payload_usdtz_plenty["content"] + " :whale:"
-                
-            else:
-                continue
-
-            channel = DISCORD_WEBHOOK
-            if int(tx['amount']) / 1e18 >= 5000 and DISCORD_WEBHOOK_WHALES is not None:
-                channel = DISCORD_WEBHOOK_WHALES
-             
-            send_discord(payload_usdtz_plenty,channel)        
-
-
 def watch_for_changes():
-
-    fetch_whales()
-        
     if os.path.exists('.shared/previous-state.json'):
         print("Found .shared/previous-state.json, bootstrapping from that!")
         with open('.shared/previous-state.json') as f:
@@ -312,28 +184,27 @@ def watch_for_changes():
             latest_usdtz_plenty_ophash = previous_state['latest-usdtz-plenty-hash']
     else:
         print("No previous state found! Starting fresh...")
-        bcd_payload_quipu = fetch_quipuswap_activity()
-        bcd_payload_plenty = fetch_plenty_activity()
-        bcd_payload_usdtz_plenty = fetch_usdtz_plenty_activity()
-        latest_quipu_ophash = bcd_payload_quipu[0]['hash']
-        latest_plenty_ophash = bcd_payload_plenty[0]['hash']
-        latest_usdtz_plenty_ophash = bcd_payload_usdtz_plenty[0]['hash']
+        _, latest_quipu_ophash = fetch_contract_transfers(QUIPU_KUSD)
+        _, latest_plenty_ophash = fetch_contract_transfers(PLENTY_KUSD)
+        _, latest_usdtz_plenty_ophash = fetch_contract_transfers(PLENTY_USDTZ_KUSD)
 
     while True:
         try:
-            new_transfers, latest_quipu_ophash, latest_plenty_ophash, latest_usdtz_plenty_ophash = fetch_all_new_transfers(
-                latest_quipu_ophash,
-                latest_plenty_ophash,
-                latest_usdtz_plenty_ophash
-                )
-            
+            (new_quipu_transfers, latest_quipu_ophash) = fetch_contract_transfers(QUIPU_KUSD, since_hash=latest_quipu_ophash)
+
+            new_plenty_transfers, latest_plenty_ophash = fetch_contract_transfers(PLENTY_KUSD, since_hash=latest_plenty_ophash)
+
+            new_usdtz_plenty_transfers, latest_usdtz_plenty_ophash = fetch_contract_transfers(PLENTY_USDTZ_KUSD, since_hash=latest_usdtz_plenty_ophash)
+
+            all_transfers = new_quipu_transfers + new_plenty_transfers + new_usdtz_plenty_transfers
+
         except Exception as exc:
             print("Exception processing contract activity! Sleeping for a bit and trying again...", exc)
             time.sleep(10)
             continue
 
-        if len(new_transfers) != 0:
-            handle_new_transfers(new_transfers[::-1])
+        if len(all_transfers) != 0:
+            handle_new_transfers(all_transfers[::-1])
 
             if not os.path.exists('.shared/previous-state.json'):
                 if not os.path.exists('.shared'):
@@ -351,4 +222,5 @@ def watch_for_changes():
             time.sleep(30)
 
 if __name__ == "__main__":
+    fetch_whales()
     watch_for_changes()


### PR DESCRIPTION
So I went through and fixed up a few things, namely got rid of some redundancies and whatnot.

Changed:
- Removed magic contract values, replacing them with definitions at the top for `QUIPU_KUSD`, `PLENTY_KUSD`, and `PLENTY_USDTZ_KUSD` (makes upgrades and reasoning about the code easier)
- If you want to default an envar it's easier to just do `os.environ.get('SOME_VAR', None)` - the second parameter is the default value if the given key isn't found/doesn't have a value. 
- Merged the `fetch_usdtz_plenty_activity`/`fetch_plenty_activity`/`fetch_quipuswap_activity` into one `fetch_contract_transfers` function - the only difference between these functions was the contract that was being requested from BCD, so this just passes it in
- Gets rid of `fetch_all_new_transfers` since it was mostly doing work to update the latest hashes, and moved that into the main `watch_for_changes` function, which also let's us get rid of the global ophash tracking stuff
- Returns both the transfers *and* the latest ophash from `fetch_contract_transfers`, which is used to update the different `latest_*_ophash` stuff
- Merges the 3 iteration loops over transfers into one guarded by contract checks

Minor Things:
- Fixed comment formatting, they should always have a space after `#` (so `# This is a comment`, not `#This is a comment`)
- Numbers can be written with `_` that'll get stripped out at runtime (so you can write 1M as `1_000_000` which is easier to read than `1000000`)
- Fixed some spacing things
- Moves `fetch_whales()` into the init at the bottom (separating out concerns a bit better)